### PR TITLE
Dealing with the invalid index assert error in DenseCoeffsBase

### DIFF
--- a/include/ball.h
+++ b/include/ball.h
@@ -47,12 +47,13 @@ namespace abacoc
 		int errors;
 		int n_updates;
 		double init_radius;
-		double radius;
+
 		VectorE center;
 
 		void updateCenter();
 
 	public:
+		double radius;
 		Ball(const long ID, const Sample &center, double radius);
 		void update(const Sample &sample, const BallPredictor &ball_predictor, const Parameters &par);
 		long getID() const;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -138,7 +138,7 @@ int Model::predict(const Data &data, double &confidence) const
 	{
 		for (auto i = 0; i < class_confidence.size(); i++)
 		{
-			if (class_confidence(i) > max_val)
+			if (class_confidence(i) >= max_val)
 			{
 				max_val = class_confidence(i);
 				index = i;
@@ -149,7 +149,7 @@ int Model::predict(const Data &data, double &confidence) const
 	{
 		for (auto i = 0; i < class_scores.size(); i++)
 		{
-			if (class_scores(i) > max_val)
+			if (class_scores(i) >= max_val)
 			{
 				max_val = class_scores(i);
 				index = i;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -133,12 +133,12 @@ int Model::predict(const Data &data, double &confidence) const
 	VectorE class_confidence = weighted_probs/data.samples.size();
 
 	int index = -1;
-	double max_val = 0.0;
+	double max_val = -std::numeric_limits<double>::max();
 	if (parameters->prediction_type == CONFIDENCE)
 	{
 		for (auto i = 0; i < class_confidence.size(); i++)
 		{
-			if (class_confidence(i) >= max_val)
+			if (class_confidence(i) > max_val)
 			{
 				max_val = class_confidence(i);
 				index = i;
@@ -149,7 +149,7 @@ int Model::predict(const Data &data, double &confidence) const
 	{
 		for (auto i = 0; i < class_scores.size(); i++)
 		{
-			if (class_scores(i) >= max_val)
+			if (class_scores(i) > max_val)
 			{
 				max_val = class_scores(i);
 				index = i;


### PR DESCRIPTION
Modified the radius visibility to prevent compilation errors in linux. 
Changed function predict in model.cpp to change the index when finding greater or equal class_confidences(i), instead of only greater.

After making these changes, the output is "Accuracy = 0.98118"
